### PR TITLE
disable semantic highlights by clangd

### DIFF
--- a/lua/lspcfg.lua
+++ b/lua/lspcfg.lua
@@ -80,6 +80,14 @@ function cfg.configure_servers()
                     }
                 })
             end,
+            clangd = function ()
+                require('lspconfig').clangd.setup({
+                    capabilities = lsp_capabilities,
+                    on_attach = function (client)
+                        client.server_capabilities.semanticTokensProvider = nil
+                    end
+                })
+            end,
         },
     })
 end


### PR DESCRIPTION
Right, I can reproduce your issue. `:Inspect`ing on these greyed out lines says treesitter is working fine, it's clangd the lsp labelling these lines as comment for some reason, and they are displayed in grey then. I'm unsure why would that be the case, bug? At least for now I'll just run away from it, as highlights from treesitter should suffice.